### PR TITLE
Next Version PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,16 @@
 
     <groupId>pw.mihou</groupId>
     <artifactId>Velen</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2-SNAPSHOT</version>
     <name>Velen</name>
     <description>Velen is a command framework for Javacord that aims to do everything simpler and easier.</description>
     <url>https://github.com/ShindouMihou/Velen/</url>
+    <repositories>
+        <repository>
+            <id>snapshots-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
     <licenses>
         <license>
             <name>Apache 2.0 License</name>
@@ -112,7 +118,7 @@
         <dependency>
             <groupId>org.javacord</groupId>
             <artifactId>javacord</artifactId>
-            <version>3.3.2</version>
+            <version>3.4.0-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
     </dependencies>

--- a/src/main/java/pw/mihou/velen/pagination/Paginate.java
+++ b/src/main/java/pw/mihou/velen/pagination/Paginate.java
@@ -2,6 +2,7 @@ package pw.mihou.velen.pagination;
 
 import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.api.entity.message.MessageBuilder;
+import org.javacord.api.entity.message.MessageUpdater;
 import org.javacord.api.entity.message.component.Button;
 import org.javacord.api.event.message.MessageCreateEvent;
 import org.javacord.api.listener.interaction.ButtonClickListener;
@@ -215,11 +216,10 @@ public class Paginate<T> {
 
             // We are adding this in case the user wants to automatically
             // free up the listener once time has passed.
-
-            // This is extremely limited atm since Javacord offers no way
-            // of removing components.
             if (!removeAfter.isZero() && !removeAfter.isNegative())
-                listener.removeAfter(removeAfter.toMillis(), TimeUnit.MILLISECONDS);
+                listener.removeAfter(removeAfter.toMillis(), TimeUnit.MILLISECONDS).addRemoveHandler(() -> new MessageUpdater(message)
+                        .removeAllComponents()
+                        .replaceMessage());
         });
     }
 
@@ -293,11 +293,10 @@ public class Paginate<T> {
 
             // We are adding this in case the user wants to automatically
             // free up the listener once time has passed.
-
-            // This is extremely limited atm since Javacord offers no way
-            // of removing components.
             if (!removeAfter.isZero() && !removeAfter.isNegative())
-                listener.removeAfter(removeAfter.toMillis(), TimeUnit.MILLISECONDS);
+                listener.removeAfter(removeAfter.toMillis(), TimeUnit.MILLISECONDS).addRemoveHandler(() -> new MessageUpdater(message)
+                        .removeAllComponents()
+                        .replaceMessage());
         });
     }
 


### PR DESCRIPTION
This is a heads-up for the next version of Velen which follows Javacord 3.4.0, to use this, please move to the Snapshot repository of Javacord:
- Paginate Messages with Buttons will now remove the buttons once the time is up.
- Javacord v3.4.0 compatiability.

To use this PR, please use [Jitpack](https://jitpack.io) to build the PR. Also to note, the snapshot repository of Javacord and the version numbering will be changed once the next version of Javacord is officially out.