### PR TITLE
Fix asRole() for VelenOption

### DIFF
--- a/src/main/java/pw/mihou/velen/interfaces/hybrid/objects/VelenOption.java
+++ b/src/main/java/pw/mihou/velen/interfaces/hybrid/objects/VelenOption.java
@@ -205,7 +205,7 @@ public class VelenOption {
         if(arg == null)
             return option.getRoleValue();
 
-        Matcher matcher = DiscordRegexPattern.CHANNEL_MENTION.matcher(arg);
+        Matcher matcher = DiscordRegexPattern.ROLE_MENTION.matcher(arg);
         if(!matcher.matches())
             return Optional.empty();
 


### PR DESCRIPTION
asRole() is using a regex to retrieve a channel mention instead of the role, causing the function to return empty optionals when used on Role options.